### PR TITLE
continue reconcile loop for fatal error case

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -375,8 +375,14 @@ func (c *Cluster) run() {
 
 		if isFatalError(rerr) {
 			c.status.SetReason(rerr.Error())
-			c.logger.Errorf("cluster failed: %v", rerr)
-			return
+			// Old behavior
+			// It is Fatal Error case, and etcdcluster would be set to Failed
+			// It would be a non-recoverable case
+
+			// New behavior
+			// To avoid that, we don't return, so it will not be set to Failed
+			// but we do log
+			c.logger.Errorf("cluster failed (however, we continue reconcile loop): %v", rerr)
 		}
 	}
 }


### PR DESCRIPTION
We have seen etcdcluster ended at a `Failed` state. Then it cannot be recovered.
After carefully checking the code, it is mostly because etcd-operator encountered a Fatal error.

The fatal error could be, failed to connection with apiserver, which happens when underlay malfunctional.

This fix is basically swallow the fatal error, continue reconcile loop, hope in the future, it can recover from fatal error.

