### PR TITLE
Streamline etcd backu sidecar patching process

### DIFF
--- a/pkg/cluster/backup_manager.go
+++ b/pkg/cluster/backup_manager.go
@@ -239,19 +239,11 @@ func (bm *backupManager) upgradeIfNeeded() error {
 	if err != nil {
 		return err
 	}
-	if d.Spec.Template.Spec.Containers[0].Image == k8sutil.BackupImage {
-		return nil
-	}
-
 	bm.logger.Infof("upgrading backup sidecar from (%v) to (%v)",
 		d.Spec.Template.Spec.Containers[0].Image, k8sutil.BackupImage)
 
 	uf := func(d *appsv1beta1.Deployment) {
-		d.Spec.Template.Spec.Containers[0].Image = k8sutil.BackupImage
-		// TODO: backward compatibility for v0.2.6 . Remove this after v0.2.7 .
-		d.Spec.Strategy = appsv1beta1.DeploymentStrategy{
-			Type: appsv1beta1.RecreateDeploymentStrategyType,
-		}
+		d.Spec = bm.makeSidecarDeployment().Spec
 	}
 	return k8sutil.PatchDeployment(bm.config.KubeCli, ns, n, uf)
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -290,13 +290,15 @@ func (c *Cluster) run() {
 				ob, nb := c.cluster.Spec.Backup, event.cluster.Spec.Backup
 				c.cluster = event.cluster
 
-				if !isBackupPolicyEqual(ob, nb) {
-					err = c.updateBackupPolicy(ob, nb)
-					if err != nil {
-						c.logger.Errorf("failed to update backup policy: %v", err)
-						c.status.SetReason(err.Error())
-						return
-					}
+				// Everytime, when cluster spec change, we have to updateBackupPolicy
+				// Not all cluster specs are within BackupPolicy, such as TLS configs
+				// When etcdcluster has TLS configs change, we have to update backup
+				// sidecar
+				err = c.updateBackupPolicy(ob, nb)
+				if err != nil {
+					c.logger.Errorf("failed to update backup policy: %v", err)
+					c.status.SetReason(err.Error())
+					return
 				}
 
 			case eventDeleteCluster:


### PR DESCRIPTION
So now the `uf` will take the latest etcdcluster.spec to generate patch. 
Before, it only patches the image and strategy