### PR TITLE
Now run defrag everytime we backup the database

### DIFF
--- a/pkg/util/constants/constants.go
+++ b/pkg/util/constants/constants.go
@@ -19,6 +19,7 @@ import "time"
 const (
 	DefaultDialTimeout      = 5 * time.Second
 	DefaultRequestTimeout   = 5 * time.Second
+	DefaultDefragTimeout    = 1 * time.Minute
 	DefaultSnapshotTimeout  = 1 * time.Minute
 	DefaultSnapshotInterval = 1800 * time.Second
 


### PR DESCRIPTION
This enables running a defrag on every cluster member every time we perform a database backup.