### PR TITLE
Allow setting cloud for abs backend

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -99,7 +99,8 @@ func New(kclient kubernetes.Interface, clusterName, ns string, sp spec.ClusterSp
 			os.Getenv(env.ABSStorageAccount),
 			os.Getenv(env.ABSStorageKey),
 			os.Getenv(env.ABSAccountSASToken),
-			path.Join(ns, clusterName))
+			path.Join(ns, clusterName),
+			os.Getenv(env.ABSCloud))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/backup/env/env.go
+++ b/pkg/backup/env/env.go
@@ -22,4 +22,5 @@ const (
 	ABSStorageAccount  = "AZURE_STORAGE_ACCOUNT"
 	ABSStorageKey      = "AZURE_STORAGE_KEY"
 	ABSAccountSASToken = "AZURE_STORAGE_ACCOUNT_SAS_TOKEN"
+	ABSCloud           = "AZURE_CLOUD"
 )

--- a/pkg/cluster/backupstorage/abs.go
+++ b/pkg/cluster/backupstorage/abs.go
@@ -37,11 +37,11 @@ func NewABSStorage(kubecli kubernetes.Interface, clusterName, ns string, p spec.
 	prefix := path.Join(ns, clusterName)
 
 	abscli, err := func() (*backupabs.ABS, error) {
-		account, key, sas, err := setupABSCreds(kubecli, ns, p.ABS.ABSSecret)
+		account, key, sas, cloud, err := setupABSCreds(kubecli, ns, p.ABS.ABSSecret)
 		if err != nil {
 			return nil, err
 		}
-		return backupabs.New(p.ABS.ABSContainer, account, key, sas, prefix)
+		return backupabs.New(p.ABS.ABSContainer, account, key, sas, prefix, cloud)
 	}()
 	if err != nil {
 		return nil, err
@@ -83,13 +83,14 @@ func (a *abs) Delete() error {
 	return nil
 }
 
-func setupABSCreds(kubecli kubernetes.Interface, ns, secret string) (account, key, sas string, err error) {
+func setupABSCreds(kubecli kubernetes.Interface, ns, secret string) (account, key, sas, cloud string, err error) {
 	se, err := kubecli.CoreV1().Secrets(ns).Get(secret, metav1.GetOptions{})
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 	account = string(se.Data[spec.ABSStorageAccount])
 	key = string(se.Data[spec.ABSStorageKey])
 	sas = string(se.Data[spec.ABSAccountSASToken])
+	cloud = string(se.Data[spec.ABSCloud])
 	return
 }

--- a/pkg/spec/backup.go
+++ b/pkg/spec/backup.go
@@ -33,6 +33,8 @@ const (
 	ABSStorageKey = "storage-key"
 	// ABSAccountSASToken defines the SAS token
 	ABSAccountSASToken = "storage-sas-token"
+	// ABSCloud defines the Azure cloud name
+	ABSCloud = "cloud"
 )
 
 var errPVZeroSize = errors.New("PV backup should not have 0 size volume")


### PR DESCRIPTION
This PR adds add support of setting Azure cloud for abs backend. e.g. cloud should be set to AzureChinaCloud for mooncake.