### PR TITLE
Make Etcd Container ImagePullPolicy Customizable

### DIFF
--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -170,6 +170,13 @@ type PodPolicy struct {
 	// AntiAffinity determines if the etcd-operator tries to avoid putting
 	// the etcd members in the same cluster onto the same node.
 	AntiAffinity bool `json:"antiAffinity,omitempty"`
+
+	// PullPolicy describes a policy for if/when to pull a container image
+	// One of PullAlways, PullNever, PullIfNotPresent.
+	// Defaults to PullAlways if :latest tag is specified, or IfNotPresent otherwise.
+	// More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+	// This field cannot be updated once the cluster is created.
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// Resources is the resource requirements for the etcd container.
 	// This field cannot be updated once the cluster is created.

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -27,7 +27,7 @@ import (
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
 
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	v1beta1storage "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -253,6 +253,7 @@ func NewBackupPodTemplate(clusterName, account string, sp spec.ClusterSpec) v1.P
 					Name:  backupenv.ClusterSpec,
 					Value: string(b),
 				}},
+				ImagePullPolicy: sp.Pod.ImagePullPolicy,
 			},
 		},
 	}

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -355,6 +355,7 @@ func CopyVolume(kubecli kubernetes.Interface, fromClusterName, toClusterName, ns
 						Name:      "to-dir",
 						MountPath: constants.BackupMountDir,
 					}},
+					ImagePullPolicy: v1.PullIfNotPresent,
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -244,7 +244,7 @@ func AddEtcdVolumeToPod(pod *v1.Pod, pvc *v1.PersistentVolumeClaim, hostPath *v1
 
 func AddRecoveryToPod(pod *v1.Pod, clusterName, token string, m *etcdutil.Member, cs spec.ClusterSpec) {
 	pod.Spec.InitContainers =
-		makeRestoreInitContainerSpec(BackupServiceAddr(clusterName), token, cs.BaseImage, cs.CurlImage, cs.Version, m)
+		makeRestoreInitContainerSpec(BackupServiceAddr(clusterName), token, cs.BaseImage, cs.CurlImage, cs.Version, cs.Pod.ImagePullPolicy, m)
 }
 
 func addOwnerRefToObject(o metav1.Object, r metav1.OwnerReference) {

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -21,7 +21,7 @@ import (
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -152,6 +152,7 @@ func applyPodPolicy(clusterName string, pod *v1.Pod, policy *spec.PodPolicy) {
 	for i := range pod.Spec.Containers {
 		if pod.Spec.Containers[i].Name == "etcd" {
 			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, policy.EtcdEnv...)
+			pod.Spec.Containers[i].ImagePullPolicy = policy.ImagePullPolicy
 		}
 	}
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -29,7 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -119,7 +119,7 @@ func (f *Framework) SetupEtcdOperator() error {
 				{
 					Name:            "etcd-operator",
 					Image:           f.opImage,
-					ImagePullPolicy: v1.PullAlways,
+					ImagePullPolicy: v1.PullIfNotPresent,
 					Command:         cmd,
 					Env: []v1.EnvVar{
 						{

--- a/test/e2e/upgradetest/framework/framework.go
+++ b/test/e2e/upgradetest/framework/framework.go
@@ -26,7 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -100,7 +100,7 @@ func (f *Framework) CreateOperator(name string) error {
 					Containers: []v1.Container{{
 						Name:            name,
 						Image:           image,
-						ImagePullPolicy: v1.PullAlways,
+						ImagePullPolicy: v1.PullIfNotPresent,
 						Command:         cmd,
 						Env: []v1.EnvVar{
 							{


### PR DESCRIPTION
To eliminate the risk when dependent registry service has outage, this PR adds ImagePullPolicy into the cluster spec and make it customizable. It is added into PodPolicy. It applies to etcd and etcd backup, and not applies to etcd operator.